### PR TITLE
docs(README): cross-promote npx skills add https://ulink.ly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ A Flutter SDK for creating and handling dynamic links with ULink, similar to Bra
 - Installation tracking
 - Clear distinction between dynamic and unified link types
 
+## AI-Assisted Setup
+
+Using Claude Code, Cursor, Codex, or another AI coding agent? Install the ULink onboarding skill in one command:
+
+```bash
+npx skills add https://ulink.ly
+```
+
+Then ask your assistant to **"setup ulink"** — it'll detect your Flutter project, configure your ULink dashboard, edit `pubspec.yaml`/`AndroidManifest.xml`/`Info.plist`, and verify the integration. Works with 50+ AI agents via the [open agent-skills CLI](https://github.com/vercel-labs/skills). [Learn more →](https://docs.ulink.ly/getting-started/ai-setup)
+
 ## Installation
 
 Add this to your `pubspec.yaml` dependencies:


### PR DESCRIPTION
## Summary

Adds an "AI-Assisted Setup" callout near the top of the README pointing at the new install command:

```bash
npx skills add https://ulink.ly
```

Cross-promotes the ULink onboarding skill, which was just published at `https://ulink.ly/.well-known/agent-skills/` and to the [open agent-skills ecosystem](https://github.com/vercel-labs/skills) (50+ supported agents).

## Why

- Most devs touching this SDK in 2026 are working with an AI coding assistant
- `npx skills add https://ulink.ly` installs a guided onboarding skill that detects the project, edits config files, and runs verification — much faster than manual SDK setup
- The well-known endpoint and the ecosystem listing are already live; this is a pure documentation cross-promote, no code change

## Changes

- `README.md` — adds "AI-Assisted Setup" section between Features and Installation