### PR TITLE
release: v0.3.0 — externalId for idempotent link creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+- Add optional `externalId` to `ULinkParameters` for idempotent link creation. Set a deterministic key (e.g. `share:user:123:post:456`) and repeat calls return the existing link instead of creating a duplicate. See https://docs.ulink.ly/create-links/idempotent-link-creation
+- Forward `externalId` end-to-end through the Kotlin and Swift native bridges
+- Bump pinned native SDKs to ULinkSDK ~> 1.1.0 (iOS) and ly.ulink:ulink-sdk:1.1.0 (Android)
+
 ## 0.2.19
 - Bump Android SDK dependency to 1.0.11 — fixes Android main-thread freeze during `ULink.initialize()` on cold start with slow or unstable networks (#8). The native `initialize()` no longer wraps `setup()` in `runBlocking`; concurrent callers now serialize via a suspend-safe `Mutex` instead of a JVM monitor.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ if (unifiedResponse.success) {
 
 ### Idempotent Link Creation
 
+> ⚠️ **Requires flutter_ulink_sdk ≥ 0.3.0.** In earlier versions the field is accepted on the Dart side but silently dropped by the native bridges before reaching the REST API — **do not rely on it for deduplication until you've upgraded.** End-to-end forwarding (Dart → native bridge → REST) ships once the native iOS and Android SDKs publish 1.1.0 and this plugin bumps its pinned versions.
+
 Pass `externalId` to avoid creating duplicates when the same share button is tapped repeatedly. ULink scopes the key to your project — repeat calls return the existing link instead of creating a new one. See the [docs](https://docs.ulink.ly/create-links/idempotent-link-creation) for full semantics.
 
 ```dart
@@ -255,11 +257,10 @@ final response = await ULink.instance.createLink(
     externalId: 'share:user:123:post:456',
   ),
 );
-// First call:        creates link, returns 201
-// Subsequent calls:  returns the same link, 200
+// SDK ≥ 0.3.0:
+//   First call:        creates link, returns 201
+//   Subsequent calls:  returns the same link, 200
 ```
-
-> **Note:** end-to-end forwarding (Dart → native bridge → REST) ships once the native iOS and Android SDKs publish 1.1.0 and this plugin bumps its pinned versions. Until then the Dart-side field is captured but the native bridges drop it before reaching the API.
 
 ## Factory Methods for Cleaner API
 

--- a/README.md
+++ b/README.md
@@ -243,8 +243,6 @@ if (unifiedResponse.success) {
 
 ### Idempotent Link Creation
 
-> ⚠️ **Requires flutter_ulink_sdk ≥ 0.3.0.** In earlier versions the field is accepted on the Dart side but silently dropped by the native bridges before reaching the REST API — **do not rely on it for deduplication until you've upgraded.** End-to-end forwarding (Dart → native bridge → REST) ships once the native iOS and Android SDKs publish 1.1.0 and this plugin bumps its pinned versions.
-
 Pass `externalId` to avoid creating duplicates when the same share button is tapped repeatedly. ULink scopes the key to your project — repeat calls return the existing link instead of creating a new one. See the [docs](https://docs.ulink.ly/create-links/idempotent-link-creation) for full semantics.
 
 ```dart
@@ -257,9 +255,8 @@ final response = await ULink.instance.createLink(
     externalId: 'share:user:123:post:456',
   ),
 );
-// SDK ≥ 0.3.0:
-//   First call:        creates link, returns 201
-//   Subsequent calls:  returns the same link, 200
+// First call:        creates link, returns 201
+// Subsequent calls:  returns the same link, 200
 ```
 
 ## Factory Methods for Cleaner API

--- a/README.md
+++ b/README.md
@@ -241,6 +241,26 @@ if (unifiedResponse.success) {
 }
 ```
 
+### Idempotent Link Creation
+
+Pass `externalId` to avoid creating duplicates when the same share button is tapped repeatedly. ULink scopes the key to your project — repeat calls return the existing link instead of creating a new one. See the [docs](https://docs.ulink.ly/create-links/idempotent-link-creation) for full semantics.
+
+```dart
+final response = await ULink.instance.createLink(
+  ULinkParameters.unified(
+    domain: 'links.shared.ly',
+    iosUrl: 'myapp://post/456',
+    androidUrl: 'myapp://post/456',
+    fallbackUrl: 'https://myapp.com/post/456',
+    externalId: 'share:user:123:post:456',
+  ),
+);
+// First call:        creates link, returns 201
+// Subsequent calls:  returns the same link, 200
+```
+
+> **Note:** end-to-end forwarding (Dart → native bridge → REST) ships once the native iOS and Android SDKs publish 1.1.0 and this plugin bumps its pinned versions. Until then the Dart-side field is captured but the native bridges drop it before reaching the API.
+
 ## Factory Methods for Cleaner API
 
 The ULink SDK provides factory methods for creating different types of links, making the API more intuitive and type-safe:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ android {
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
         
         // ULink Android SDK dependency from Maven Central
-        implementation "ly.ulink:ulink-sdk:1.0.11"
+        implementation "ly.ulink:ulink-sdk:1.1.0"
         
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")

--- a/android/src/main/kotlin/com/example/flutter_ulink_sdk/FlutterUlinkSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_ulink_sdk/FlutterUlinkSdkPlugin.kt
@@ -576,7 +576,8 @@ class FlutterUlinkSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Pl
       fallbackUrl = parametersMap["fallbackUrl"] as? String,
       parameters = parametersConverted,
       socialMediaTags = socialMediaTags,
-      metadata = metadataConverted
+      metadata = metadataConverted,
+      externalId = parametersMap["externalId"] as? String
     )
   }
   

--- a/ios/Classes/FlutterUlinkSdkPlugin.swift
+++ b/ios/Classes/FlutterUlinkSdkPlugin.swift
@@ -850,20 +850,21 @@ public class FlutterUlinkSdkPlugin: NSObject, FlutterPlugin {
         let fallbackUrl = map["fallbackUrl"] as? String
         let additionalParameters = map["parameters"] as? [String: String]
         let metadata = map["metadata"] as? [String: Any]
-        
+        let externalId = map["externalId"] as? String
+
         var socialTags: SocialMediaTags? = nil
         if let socialMediaArgs = map["socialMediaTags"] as? [String: Any] {
             let ogTitle = socialMediaArgs["ogTitle"] as? String
             let ogDescription = socialMediaArgs["ogDescription"] as? String
             let ogImage = socialMediaArgs["ogImage"] as? String
-            
+
             socialTags = SocialMediaTags(
                 ogTitle: ogTitle,
                 ogDescription: ogDescription,
                 ogImage: ogImage
             )
         }
-        
+
         let parameters: ULinkParameters
         if type == "dynamic" {
             parameters = ULinkParameters.dynamic(
@@ -875,13 +876,14 @@ public class FlutterUlinkSdkPlugin: NSObject, FlutterPlugin {
                 fallbackUrl: fallbackUrl,
                 parameters: additionalParameters,
                 socialMediaTags: socialTags,
-                metadata: metadata
+                metadata: metadata,
+                externalId: externalId
             )
         } else {
             let iosUrl = map["iosUrl"] as? String ?? ""
             let androidUrl = map["androidUrl"] as? String ?? ""
             let fallbackUrlRequired = fallbackUrl ?? ""
-            
+
             parameters = ULinkParameters.unified(
                 domain: domain,
                 slug: slug,
@@ -891,10 +893,11 @@ public class FlutterUlinkSdkPlugin: NSObject, FlutterPlugin {
                 fallbackUrl: fallbackUrlRequired,
                 parameters: additionalParameters,
                 socialMediaTags: socialTags,
-                metadata: metadata
+                metadata: metadata,
+                externalId: externalId
             )
         }
-        
+
         return parameters
     }
     

--- a/ios/flutter_ulink_sdk.podspec
+++ b/ios/flutter_ulink_sdk.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ULinkSDK', '~> 1.0.8'
+  s.dependency 'ULinkSDK', '~> 1.1.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/models/ulink_parameters.dart
+++ b/lib/models/ulink_parameters.dart
@@ -45,9 +45,11 @@ class ULinkParameters {
   /// link on repeat calls instead of creating a duplicate. Pick a deterministic
   /// key from your system, e.g. `share:user:123:post:456`.
   ///
-  /// Note: end-to-end plumbing (Dart -> bridge -> native -> REST) ships
-  /// once the native SDKs publish 1.1.0 and this plugin bumps its pinned
-  /// versions. Until then this field is captured but the bridges drop it.
+  /// **Requires flutter_ulink_sdk ≥ 0.3.0 to actually take effect.** In
+  /// earlier versions the field is accepted on the Dart side but silently
+  /// dropped by the native bridges before reaching the REST API. End-to-end
+  /// plumbing (Dart -> bridge -> native -> REST) ships once the native SDKs
+  /// publish 1.1.0 and this plugin bumps its pinned versions.
   final String? externalId;
 
   /// Creates a new set of ULink parameters

--- a/lib/models/ulink_parameters.dart
+++ b/lib/models/ulink_parameters.dart
@@ -40,6 +40,16 @@ class ULinkParameters {
   /// when projects have multiple domains configured.
   final String domain;
 
+  /// Optional caller-supplied identifier used to make link creation idempotent.
+  /// When set, ULink scopes the key to your project and returns the existing
+  /// link on repeat calls instead of creating a duplicate. Pick a deterministic
+  /// key from your system, e.g. `share:user:123:post:456`.
+  ///
+  /// Note: end-to-end plumbing (Dart -> bridge -> native -> REST) ships
+  /// once the native SDKs publish 1.1.0 and this plugin bumps its pinned
+  /// versions. Until then this field is captured but the bridges drop it.
+  final String? externalId;
+
   /// Creates a new set of ULink parameters
   ULinkParameters({
     this.type = 'dynamic',
@@ -54,6 +64,7 @@ class ULinkParameters {
     this.parameters,
     this.socialMediaTags,
     this.metadata,
+    this.externalId,
   });
 
   /// Factory constructor for creating dynamic links
@@ -67,6 +78,7 @@ class ULinkParameters {
     String? fallbackUrl,
     Map<String, dynamic>? parameters,
     SocialMediaTags? socialMediaTags,
+    String? externalId,
   }) {
     return ULinkParameters(
       type: 'dynamic',
@@ -78,6 +90,7 @@ class ULinkParameters {
       fallbackUrl: fallbackUrl,
       parameters: parameters,
       socialMediaTags: socialMediaTags,
+      externalId: externalId,
     );
   }
 
@@ -92,6 +105,7 @@ class ULinkParameters {
     String? fallbackUrl,
     Map<String, dynamic>? parameters,
     SocialMediaTags? socialMediaTags,
+    String? externalId,
   }) {
     return ULinkParameters(
       type: 'unified',
@@ -103,6 +117,7 @@ class ULinkParameters {
       fallbackUrl: fallbackUrl,
       parameters: parameters,
       socialMediaTags: socialMediaTags,
+      externalId: externalId,
     );
   }
 
@@ -121,6 +136,7 @@ class ULinkParameters {
     if (androidFallbackUrl != null)
       data['androidFallbackUrl'] = androidFallbackUrl;
     if (fallbackUrl != null) data['fallbackUrl'] = fallbackUrl;
+    if (externalId != null) data['externalId'] = externalId;
     if (parameters != null) data['parameters'] = parameters;
     if (socialMediaTags != null)
       data['socialMediaTags'] = socialMediaTags!.toJson();
@@ -150,6 +166,7 @@ class ULinkParameters {
       metadata: json['metadata'] != null
           ? Map<String, dynamic>.from(json['metadata'])
           : null,
+      externalId: json['externalId'],
     );
   }
 }

--- a/lib/models/ulink_parameters.dart
+++ b/lib/models/ulink_parameters.dart
@@ -44,12 +44,6 @@ class ULinkParameters {
   /// When set, ULink scopes the key to your project and returns the existing
   /// link on repeat calls instead of creating a duplicate. Pick a deterministic
   /// key from your system, e.g. `share:user:123:post:456`.
-  ///
-  /// **Requires flutter_ulink_sdk ≥ 0.3.0 to actually take effect.** In
-  /// earlier versions the field is accepted on the Dart side but silently
-  /// dropped by the native bridges before reaching the REST API. End-to-end
-  /// plumbing (Dart -> bridge -> native -> REST) ships once the native SDKs
-  /// publish 1.1.0 and this plugin bumps its pinned versions.
   final String? externalId;
 
   /// Creates a new set of ULink parameters

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ulink_sdk
 description: "Flutter SDK for creating and handling dynamic links, similar to Branch.io"
-version: 0.2.19
+version: 0.3.0
 homepage: https://github.com/mohn93/flutter_ulink_sdk
 
 environment:

--- a/test/external_id_test.dart
+++ b/test/external_id_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_ulink_sdk/models/models.dart';
+
+/// Tests for `externalId` on ULinkParameters. The field opts callers into
+/// idempotent link creation server-side — repeated calls with the same key
+/// return the existing link instead of creating a duplicate. See
+/// https://docs.ulink.ly/create-links/idempotent-link-creation
+///
+/// The native bridges (Kotlin / Swift) read `externalId` from the
+/// method-channel map and forward it to the native ULinkParameters
+/// constructors, which currently DO NOT have the field on published
+/// pinned versions. Those bridge + podspec/build.gradle bumps land in a
+/// follow-up PR once the native SDKs publish 1.1.0.
+void main() {
+  group('ULinkParameters.unified externalId', () {
+    test('serializes externalId in toJson when set', () {
+      final params = ULinkParameters.unified(
+        domain: 'links.shared.ly',
+        iosUrl: 'myapp://post/456',
+        androidUrl: 'myapp://post/456',
+        fallbackUrl: 'https://example.com/post/456',
+        externalId: 'share:user:123:post:456',
+      );
+
+      expect(params.externalId, 'share:user:123:post:456');
+      expect(params.toJson()['externalId'], 'share:user:123:post:456');
+    });
+
+    test('omits externalId from toJson when null', () {
+      final params = ULinkParameters.unified(
+        domain: 'links.shared.ly',
+        iosUrl: 'myapp://post/456',
+        androidUrl: 'myapp://post/456',
+        fallbackUrl: 'https://example.com/post/456',
+      );
+
+      expect(params.externalId, isNull);
+      expect(params.toJson().containsKey('externalId'), isFalse);
+    });
+  });
+
+  group('ULinkParameters.dynamic externalId', () {
+    test('serializes externalId in toJson when set', () {
+      final params = ULinkParameters.dynamic(
+        domain: 'links.shared.ly',
+        externalId: 'campaign:summer-sale-2026',
+      );
+
+      expect(params.externalId, 'campaign:summer-sale-2026');
+      expect(params.toJson()['externalId'], 'campaign:summer-sale-2026');
+    });
+
+    test('omits externalId from toJson when null', () {
+      final params = ULinkParameters.dynamic(domain: 'links.shared.ly');
+
+      expect(params.externalId, isNull);
+      expect(params.toJson().containsKey('externalId'), isFalse);
+    });
+  });
+
+  group('ULinkParameters.fromJson externalId', () {
+    test('round-trips externalId through fromJson', () {
+      final original = ULinkParameters.unified(
+        domain: 'links.shared.ly',
+        iosUrl: 'a',
+        androidUrl: 'b',
+        fallbackUrl: 'c',
+        externalId: 'roundtrip:abc',
+      );
+
+      final restored = ULinkParameters.fromJson(original.toJson());
+
+      expect(restored.externalId, 'roundtrip:abc');
+    });
+
+    test('parses externalId as null when absent', () {
+      final restored = ULinkParameters.fromJson({
+        'type': 'unified',
+        'domain': 'links.shared.ly',
+      });
+
+      expect(restored.externalId, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Promotes the externalId feature from develop to main so it can be tagged as v0.3.0 and published to pub.dev.

## What's in this release

- `feat(parameters): add optional externalId for idempotent link creation (Dart layer)` (originally merged in #10 as the draft Dart-only PR)
- `docs(parameters): strengthen externalId silent-drop warning` (interim review-feedback commit; warnings are now removed since end-to-end works)
- `feat(bridges): forward externalId end-to-end; bump native deps to 1.1.0` (the deferred follow-up — bumps pinned native SDKs to ULinkSDK 1.1.0 on iOS + ly.ulink:ulink-sdk:1.1.0 on Android, wires both bridges, removes temporary "silent drop" warnings, bumps pubspec to 0.3.0, adds CHANGELOG entry)

## Wire-level behavior

- New `externalId: String?` on `ULinkParameters` and both factory constructors (`dynamic`, `unified`)
- Serialized into the method-channel map → forwarded by Kotlin + Swift bridges to the native `ULinkParameters` constructors → ends up in the REST API JSON body as `externalId`
- Omitted when null at every layer (Dart `toJson`, bridge bridges, native serializer)
- Native dep bumps: `ULinkSDK ~> 1.0.8 → ~> 1.1.0` and `ly.ulink:ulink-sdk:1.0.11 → 1.1.0`

## Backward compatibility

Fully additive. `externalId` defaults to null on both factory constructors; existing call sites compile and behave identically.

## Test plan

- [x] `flutter test` — 52/52 green (including the 6 new externalId tests in `test/external_id_test.dart`)
- [x] `flutter analyze` — clean (4 pre-existing style infos)
- [x] `flutter pub publish --dry-run` (the `dry-run` CI check) — passes
- [x] `cd example && flutter build apk --debug` — `ly.ulink:ulink-sdk:1.1.0` resolves from Maven Central
- [x] `cd example && flutter build ios --no-codesign --debug` — `ULinkSDK (1.1.0)` resolves from CocoaPods CDN
- [ ] Post-merge: tag v0.3.0 → CI publishes to pub.dev via OIDC + creates GitHub Release

Sibling native releases: iOS [v1.1.0](https://github.com/mohn93/ios_ulink_sdk/releases/tag/v1.1.0) on CocoaPods, Android [v1.1.0](https://github.com/mohn93/android_ulink_sdk/releases/tag/v1.1.0) on Maven Central — both live.