### PR TITLE
chore(ios): require ULinkSDK ~> 1.1.1 for query-param fix (v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.3
+- Bump pinned native iOS SDK to `ULinkSDK ~> 1.1.1`, which fixes iOS-only loss of appended query parameters during link resolution. On iOS the deep link was sent to `/sdk/resolve` with `&`/`=` left unencoded, so the server saw only the first appended parameter (e.g. `?app=poc&screen=product&id=123` resolved to just `{app: poc}`); every parameter after the first was dropped. Android was unaffected. Requires rebuilding the iOS app against the updated pod/SwiftPM dependency.
+
 ## 0.3.2
 - Migrate the Android plugin to Flutter's Built-in Kotlin model: the plugin no longer applies the Kotlin Gradle Plugin (KGP) via its own buildscript classpath. KGP is now applied conditionally only on AGP < 9 (`apply plugin: "kotlin-android"`); on AGP 9+ Flutter's built-in Kotlin is used. This removes `flutter_ulink_sdk` from the "plugins that apply KGP" build warning and keeps it building on future Flutter releases. See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
 - Replace the deprecated `kotlinOptions { jvmTarget }` block with the `kotlin { compilerOptions { jvmTarget } }` DSL.

--- a/ios/flutter_ulink_sdk.podspec
+++ b/ios/flutter_ulink_sdk.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'flutter_ulink_sdk/Sources/flutter_ulink_sdk/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'ULinkSDK', '~> 1.1.0'
+  s.dependency 'ULinkSDK', '~> 1.1.1'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/flutter_ulink_sdk/Package.swift
+++ b/ios/flutter_ulink_sdk/Package.swift
@@ -12,9 +12,9 @@ let package = Package(
         .library(name: "flutter-ulink-sdk", targets: ["flutter_ulink_sdk"])
     ],
     dependencies: [
-        // Native ULink iOS SDK. Mirrors the `ULinkSDK ~> 1.1.0` CocoaPods
+        // Native ULink iOS SDK. Mirrors the `ULinkSDK ~> 1.1.1` CocoaPods
         // dependency declared in flutter_ulink_sdk.podspec.
-        .package(url: "https://github.com/mohn93/ios_ulink_sdk.git", from: "1.1.0")
+        .package(url: "https://github.com/mohn93/ios_ulink_sdk.git", from: "1.1.1")
     ],
     targets: [
         .target(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ulink_sdk
 description: "Flutter SDK for creating and handling dynamic links, similar to Branch.io"
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/mohn93/flutter_ulink_sdk
 
 environment:


### PR DESCRIPTION
## Why
Companion to ios_ulink_sdk#10. On **iOS**, deep link resolution dropped every appended query parameter after the first (`?app=poc&screen=product&id=123` resolved to just `{app: poc}`). The Flutter plugin delegates iOS resolution to the native `ULinkSDK`, so it inherited the bug; Android was unaffected.

The fix lives in the native iOS SDK (`1.1.1`). This PR raises the plugin's pinned floor so consumers actually pull it in.

## Changes
- `ios/flutter_ulink_sdk.podspec`: `ULinkSDK '~> 1.1.0'` -> `'~> 1.1.1'`
- `ios/flutter_ulink_sdk/Package.swift`: SwiftPM `from: "1.1.0"` -> `"1.1.1"` (+ mirrored comment)
- `pubspec.yaml`: `0.3.2` -> `0.3.3`
- `CHANGELOG.md`: `0.3.3` entry

`~>`/`from` already *allowed* 1.1.1, but an existing `Podfile.lock` / `Package.resolved` pinned at 1.1.0 would keep the bug on rebuild; raising the floor forces the fix on next resolve.

## Release ordering
**ios_ulink_sdk v1.1.1 must be published first** (CocoaPods + GitHub release for SPM), otherwise plugin dependency resolution can't find 1.1.1. Then tag/publish this plugin `0.3.3` to pub.dev. Consumers must rebuild the iOS app to get the fix.