### PR TITLE
fix(android): bump native SDK pin to 1.1.1 (fix client-version telemetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.4
+- Bump pinned native Android SDK to `ly.ulink:ulink-sdk:1.1.1`, which fixes a client-version telemetry mismatch — the 1.1.0 artifact was sending `X-ULink-Client-Version: 1.0.11` on all backend calls (bootstrap, sessions/start, sessions/end, resolve, deferred match). Version header now reports the correct `1.1.1`. iOS was unaffected (already correct in 0.3.3).
+
 ## 0.3.3
 - Bump pinned native iOS SDK to `ULinkSDK ~> 1.1.1`, which fixes iOS-only loss of appended query parameters during link resolution. On iOS the deep link was sent to `/sdk/resolve` with `&`/`=` left unencoded, so the server saw only the first appended parameter (e.g. `?app=poc&screen=product&id=123` resolved to just `{app: poc}`); every parameter after the first was dropped. Android was unaffected. Requires rebuilding the iOS app against the updated pod/SwiftPM dependency.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ android {
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
         
         // ULink Android SDK dependency from Maven Central
-        implementation "ly.ulink:ulink-sdk:1.1.0"
+        implementation "ly.ulink:ulink-sdk:1.1.1"
         
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ulink_sdk
 description: "Flutter SDK for creating and handling dynamic links, similar to Branch.io"
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/mohn93/flutter_ulink_sdk
 
 environment:


### PR DESCRIPTION
## Problem
The Flutter plugin's Android dependency pinned `ly.ulink:ulink-sdk:1.1.0`. That artifact had `SDK_VERSION` hardcoded to `"1.0.11"`, so every backend call from Flutter-on-Android sent `X-ULink-Client-Version: 1.0.11`. Fixed in native `1.1.1` (SDK_VERSION now wired to the Gradle version via BuildConfig — see [android_ulink_sdk PR #8](https://github.com/mohn93/android_ulink_sdk/pull/8)).

## Changes
- `android/build.gradle`: `ly.ulink:ulink-sdk:1.1.0` → `1.1.1`
- `pubspec.yaml`: `0.3.3` → `0.3.4`
- `CHANGELOG.md`: add 0.3.4 entry

iOS was already correct in 0.3.3 (`ULinkSDK ~> 1.1.1`).