### PR TITLE
docs: add ULink SDKs cross-link section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ and the Flutter guide for
 
 A Flutter SDK for creating and handling dynamic links with ULink, similar to Branch.io.
 
+## ULink SDKs
+
+ULink ships native SDKs for every major mobile platform:
+
+- **iOS** — [`ULinkSDK`](https://docs.ulink.ly/getting-started/ios) (CocoaPods + SPM)
+- **Android** — [`ly.ulink:ulink-sdk`](https://docs.ulink.ly/getting-started/android) (Maven Central)
+- **Flutter** — [`flutter_ulink_sdk`](https://docs.ulink.ly/getting-started/flutter) (pub.dev)
+- **React Native / Expo** — [`@ulinkly/react-native`](https://docs.ulink.ly/getting-started/react-native) (npm)
+
 ## Features
 
 - Create dynamic links with custom slugs and parameters


### PR DESCRIPTION
Adds a "ULink SDKs" section linking all four SDKs (iOS/Android/Flutter/React Native) via absolute docs URLs. Part of the multi-repo React Native rollout.